### PR TITLE
Implement basic bitwise character set

### DIFF
--- a/src/pattern/charset.rs
+++ b/src/pattern/charset.rs
@@ -1,0 +1,72 @@
+pub trait CharSet {
+    fn new() -> Self;
+    fn insert(&mut self, c: char);
+    fn contains(&self, c: char) -> bool;
+}
+
+pub struct EnCharSet {
+    bits: u32,
+}
+
+impl EnCharSet {
+    fn as_bit(c: char) -> u32 {
+        debug_assert!(c.is_ascii_lowercase());
+        1 << (c as u32 - 'a' as u32)
+    }
+}
+
+impl CharSet for EnCharSet {
+    fn new() -> Self {
+        Self { bits: 0 }
+    }
+
+    fn insert(&mut self, c: char) {
+        self.bits |= Self::as_bit(c);
+    }
+
+    fn contains(&self, c: char) -> bool {
+        if !c.is_ascii_lowercase() {
+            return false;
+        }
+        Self::as_bit(c) & self.bits > 0
+    }
+}
+
+impl FromIterator<char> for EnCharSet {
+    fn from_iter<T>(chars: T) -> Self
+    where
+        T: IntoIterator<Item = char>,
+    {
+        let mut bits: u32 = 0;
+        for c in chars.into_iter() {
+            bits |= Self::as_bit(c);
+        }
+        Self { bits }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_encharset_new() {
+        let test_chars = "asdf";
+        let mut set = EnCharSet::new();
+        for c in test_chars.chars() {
+            set.insert(c);
+        }
+        for c in "abcdefghijklmnopqrstuvwxyz".chars() {
+            assert_eq!(set.contains(c), test_chars.contains(c));
+        }
+    }
+
+    #[test]
+    fn test_encharset_from_iter() {
+        let test_chars = "asdf";
+        let set = EnCharSet::from_iter(test_chars.chars());
+        for c in "abcdefghijklmnopqrstuvwxyz".chars() {
+            assert_eq!(set.contains(c), test_chars.contains(c));
+        }
+    }
+}

--- a/src/pattern/charset.rs
+++ b/src/pattern/charset.rs
@@ -1,5 +1,9 @@
-pub trait CharSet {
+pub const EN_VOWELS: u32 = 0x00104111;
+pub const EN_CONSONANTS: u32 = 0x03efbeee;
+
+pub trait CharSet<T> {
     fn new() -> Self;
+    fn from_mask(mask: T) -> Self;
     fn insert(&mut self, c: char);
     fn contains(&self, c: char) -> bool;
 }
@@ -15,9 +19,13 @@ impl EnCharSet {
     }
 }
 
-impl CharSet for EnCharSet {
+impl CharSet<u32> for EnCharSet {
     fn new() -> Self {
         Self { bits: 0 }
+    }
+
+    fn from_mask(mask: u32) -> Self {
+        Self { bits: mask }
     }
 
     fn insert(&mut self, c: char) {

--- a/src/pattern/mod.rs
+++ b/src/pattern/mod.rs
@@ -1,7 +1,7 @@
 pub mod charset;
 pub mod parsing;
 
-use self::charset::{CharSet, EnCharSet};
+use self::charset::*;
 use self::parsing::{ParsingError, Token};
 
 enum Node {
@@ -65,11 +65,11 @@ impl<'a, 'b> Pattern {
             Node::Set(s) => s.contains(w),
             Node::NegSet(s) => !s.contains(w),
             Node::AnyVow => {
-                let vowels = EnCharSet::from_iter("aeiou".chars());
+                let vowels = EnCharSet::from_mask(EN_VOWELS);
                 vowels.contains(w)
             }
             Node::AnyCon => {
-                let consonants = EnCharSet::from_iter("bcdfghjklmnpqrstvwxyz".chars());
+                let consonants = EnCharSet::from_mask(EN_CONSONANTS);
                 consonants.contains(w)
             }
         })


### PR DESCRIPTION
A rudimentary implementation that should generalize to other languages. That it fails to handle out-of-range characters is undesirable, but I'm not sure what the most idiomatic alternative is. `Result<(), IllegalCharacterError>`?

Closes #1 