### PR TITLE
Add automata implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ thiserror = "1.0.40"
 
 [dev-dependencies]
 criterion = "0.4.0"
+proptest = "1.2.0"
 
 [[bench]]
 name = "matching"

--- a/src/parsing/qat.pest
+++ b/src/parsing/qat.pest
@@ -7,4 +7,4 @@ set_range = { letter ~ "-" ~ letter }
 set = { "[" ~ (set_range | letter)+ ~ "]" }
 negset = { "[!" ~ (set_range | letter)+ ~ "]" }
 
-pattern = { (letter | dot | consonant | vowel | set | negset)+ }
+pattern = { (letter | dot | consonant | vowel | set | negset)* }

--- a/src/pattern/automata.rs
+++ b/src/pattern/automata.rs
@@ -1,0 +1,69 @@
+use pest::iterators::{Pair, Pairs};
+
+use crate::parsing::Rule;
+
+use super::charset::{CharSet, EnCharSet};
+
+#[derive(Debug)]
+pub struct PatternNode {
+    pub matches: EnCharSet,
+    pub out: Vec<Box<PatternNode>>,
+}
+
+impl PatternNode {
+    fn make_set(pair: Pair<Rule>) -> EnCharSet {
+        let mut set = EnCharSet::new();
+        pair.into_inner().for_each(|p| match p.as_rule() {
+            Rule::letter => set.insert(p.as_str().chars().next().unwrap()),
+            Rule::set_range => {
+                let mut chars = p.as_str().chars();
+                let left = chars.next().expect("could not parse set range");
+                let right = chars.nth(1).expect("could not parse set range");
+                for c in left..=right {
+                    set.insert(c);
+                }
+            }
+            r => panic!("invalid set contents {:?}", r),
+        });
+        set
+    }
+
+    pub fn new(mut tree: Pairs<'_, Rule>) -> Option<Self> {
+        let pair = tree.next()?;
+        let follow = Self::new(tree);
+        let matches = match pair.as_rule() {
+            Rule::letter => EnCharSet::from_iter(pair.as_str().chars()),
+            Rule::dot => EnCharSet::any(),
+            Rule::vowel => EnCharSet::vowels(),
+            Rule::consonant => EnCharSet::consonants(),
+            Rule::set => Self::make_set(pair),
+            Rule::negset => Self::make_set(pair).negate(),
+            r => panic!("unrecognized rule {:?}", r),
+        };
+        match follow {
+            None => Some(Self {
+                matches,
+                out: vec![],
+            }),
+            Some(anode) => Some(Self {
+                matches,
+                out: vec![Box::new(anode)],
+            }),
+        }
+    }
+
+    pub fn test(&self, word: &str, idx: usize) -> bool {
+        if idx >= word.len() {
+            return true;
+        }
+        // TODO terrible indexing method for now, fix later
+        if !self.matches.contains(word.chars().nth(idx).unwrap()) {
+            return false;
+        }
+        if self.out.is_empty() {
+            word.len() == idx + 1
+        } else {
+            self.out.iter().any(|n| n.test(word, idx + 1))
+        }
+    }
+}

--- a/src/pattern/automata.rs
+++ b/src/pattern/automata.rs
@@ -8,6 +8,7 @@ use super::charset::{CharSet, EnCharSet};
 pub struct PatternNode {
     pub matches: EnCharSet,
     pub out: Vec<Box<PatternNode>>,
+    pub is_terminal: bool,
 }
 
 impl PatternNode {
@@ -44,26 +45,30 @@ impl PatternNode {
             None => Some(Self {
                 matches,
                 out: vec![],
+                is_terminal: true,
             }),
             Some(anode) => Some(Self {
                 matches,
                 out: vec![Box::new(anode)],
+                is_terminal: false,
             }),
         }
     }
 
     pub fn test(&self, word: &str, idx: usize) -> bool {
-        if idx >= word.len() {
-            return true;
+        if idx + 1 >= word.len() {
+            if idx == word.len() {
+                return self.is_terminal;
+            }
+            return self.is_terminal && self.matches.contains(word.chars().nth(idx).unwrap());
         }
         // TODO terrible indexing method for now, fix later
         if !self.matches.contains(word.chars().nth(idx).unwrap()) {
             return false;
         }
-        if self.out.is_empty() {
-            word.len() == idx + 1
-        } else {
-            self.out.iter().any(|n| n.test(word, idx + 1))
+        if self.is_terminal && idx + 1 == word.len() {
+            return true;
         }
+        self.out.iter().any(|n| n.test(word, idx + 1))
     }
 }

--- a/src/pattern/charset.rs
+++ b/src/pattern/charset.rs
@@ -1,13 +1,14 @@
 use core::fmt::Debug;
 
-pub const EN_VOWELS: EnCharSet = EnCharSet { bits: 0x00104111 };
-pub const EN_CONSONANTS: EnCharSet = EnCharSet { bits: 0x03efbeee };
-
 pub trait CharSet<T> {
     fn new() -> Self;
+    fn any() -> Self;
+    fn vowels() -> Self;
+    fn consonants() -> Self;
     fn from_mask(mask: T) -> Self;
     fn insert(&mut self, c: char);
     fn contains(&self, c: char) -> bool;
+    fn negate(&self) -> Self;
 }
 
 pub struct EnCharSet {
@@ -26,6 +27,18 @@ impl CharSet<u32> for EnCharSet {
         Self { bits: 0 }
     }
 
+    fn any() -> Self {
+        Self { bits: u32::MAX }
+    }
+
+    fn vowels() -> Self {
+        Self { bits: 0x00104111 }
+    }
+
+    fn consonants() -> Self {
+        Self { bits: 0x03efbeee }
+    }
+
     fn from_mask(mask: u32) -> Self {
         Self { bits: mask }
     }
@@ -39,6 +52,10 @@ impl CharSet<u32> for EnCharSet {
             return false;
         }
         Self::as_bit(c) & self.bits > 0
+    }
+
+    fn negate(&self) -> Self {
+        Self { bits: !self.bits }
     }
 }
 

--- a/src/pattern/mod.rs
+++ b/src/pattern/mod.rs
@@ -1,73 +1,24 @@
+pub mod automata;
 pub mod charset;
 
-use pest::iterators::Pair;
-
-use self::charset::{CharSet, EnCharSet, EN_CONSONANTS, EN_VOWELS};
+use self::automata::PatternNode;
 use crate::pest::{error::Error, Parser};
 
 use super::parsing::{QatParser, Rule};
 
 #[derive(Debug)]
-enum Node {
-    Letter(char),
-    Set(EnCharSet),
-    NegSet(EnCharSet),
-    Any,
-    Vowel,
-    Consonant,
-}
-
-#[derive(Debug)]
 pub struct Pattern {
-    nodes: Vec<Node>,
+    node: PatternNode,
 }
 
 impl Pattern {
-    fn make_set(pair: Pair<Rule>) -> EnCharSet {
-        let mut set = EnCharSet::new();
-        pair.into_inner().for_each(|p| match p.as_rule() {
-            Rule::letter => set.insert(p.as_str().chars().next().unwrap()),
-            Rule::set_range => {
-                let mut chars = p.as_str().chars();
-                let left = chars.next().expect("could not parse set range");
-                let right = chars.nth(1).expect("could not parse set range");
-                for c in left..=right {
-                    set.insert(c);
-                }
-            }
-            r => panic!("invalid set contents {:?}", r),
-        });
-        set
-    }
-
     pub fn new(source: &str) -> Result<Self, Box<Error<Rule>>> {
         let tree = QatParser::parse(Rule::pattern, source)?.next().unwrap();
-        let nodes = tree
-            .into_inner()
-            .map(|p| match p.as_rule() {
-                Rule::letter => Node::Letter(p.as_str().chars().next().unwrap()),
-                Rule::dot => Node::Any,
-                Rule::vowel => Node::Vowel,
-                Rule::consonant => Node::Consonant,
-                Rule::set => Node::Set(Self::make_set(p)),
-                Rule::negset => Node::NegSet(Self::make_set(p)),
-                r => panic!("unrecognized rule {:?}", r),
-            })
-            .collect();
-        Ok(Self { nodes })
+        let node = PatternNode::new(tree.into_inner()).unwrap();
+        Ok(Self { node })
     }
 
     pub fn matches(&self, word: &str) -> bool {
-        self.nodes
-            .iter()
-            .zip(word.chars())
-            .all(|(node, w)| match node {
-                Node::Letter(c) => w == *c,
-                Node::Set(s) => s.contains(w),
-                Node::NegSet(s) => !s.contains(w),
-                Node::Vowel => EN_VOWELS.contains(w),
-                Node::Consonant => EN_CONSONANTS.contains(w),
-                Node::Any => true,
-            })
+        self.node.test(word, 0)
     }
 }

--- a/src/pattern/mod.rs
+++ b/src/pattern/mod.rs
@@ -1,7 +1,10 @@
 pub mod automata;
 pub mod charset;
 
-use self::{automata::PatternNode, charset::{CharSet, EnCharSet}};
+use self::{
+    automata::PatternNode,
+    charset::{CharSet, EnCharSet},
+};
 use crate::pest::{error::Error, Parser};
 
 use super::parsing::{QatParser, Rule};
@@ -17,7 +20,13 @@ impl Pattern {
         let node = PatternNode::new(tree.into_inner());
         match node {
             Some(n) => Ok(Self { node: n }),
-            None => Ok(Self { node: PatternNode { matches: EnCharSet::new(), out: vec![], is_terminal: true }})
+            None => Ok(Self {
+                node: PatternNode {
+                    matches: EnCharSet::new(),
+                    out: vec![],
+                    is_terminal: true,
+                },
+            }),
         }
     }
 

--- a/src/pattern/mod.rs
+++ b/src/pattern/mod.rs
@@ -1,7 +1,7 @@
 pub mod automata;
 pub mod charset;
 
-use self::automata::PatternNode;
+use self::{automata::PatternNode, charset::{CharSet, EnCharSet}};
 use crate::pest::{error::Error, Parser};
 
 use super::parsing::{QatParser, Rule};
@@ -14,8 +14,11 @@ pub struct Pattern {
 impl Pattern {
     pub fn new(source: &str) -> Result<Self, Box<Error<Rule>>> {
         let tree = QatParser::parse(Rule::pattern, source)?.next().unwrap();
-        let node = PatternNode::new(tree.into_inner()).unwrap();
-        Ok(Self { node })
+        let node = PatternNode::new(tree.into_inner());
+        match node {
+            Some(n) => Ok(Self { node: n }),
+            None => Ok(Self { node: PatternNode { matches: EnCharSet::new(), out: vec![], is_terminal: true }})
+        }
     }
 
     pub fn matches(&self, word: &str) -> bool {

--- a/tests/matching-tests.proptest-regressions
+++ b/tests/matching-tests.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 5c6506cde1ea8a5caa7d613c77a4060b713ea7a2bc9cbf5bd85924ff95a5c495 # shrinks to s = ""
+cc 216b713711fbc34b3d7134cef53c2f8ec92399397657712313af4aad951ac3de # shrinks to s = "laa"

--- a/tests/matching-tests.rs
+++ b/tests/matching-tests.rs
@@ -3,6 +3,12 @@ use wordqat::pattern::Pattern;
 
 proptest! {
     #[test]
+    fn test_compilation_no_panic(s in ".*") {
+        let pattern = Pattern::new(s.as_str());
+        assert!(pattern.is_ok() || pattern.is_err());
+    }
+
+    #[test]
     fn test_matches_fixed(s in "[a-z]+") {
         let pattern = Pattern::new(s.as_str()).unwrap();
         assert_eq!(pattern.matches(s.as_str()), true);
@@ -31,28 +37,42 @@ proptest! {
         let pattern = Pattern::new("l..e").unwrap();
         assert_eq!(pattern.matches(s.as_str()), false);
     }
-}
 
-#[test]
-fn test_matches_set() {
-    let wordlist = ["anise", "avize", "alone", "elide", "risen"];
-    let pattern = Pattern::new("..i[sz]e").unwrap();
-    let result: Vec<&str> = wordlist
-        .into_iter()
-        .filter(|w| pattern.matches(w))
-        .collect();
-    assert_eq!(result, vec!["anise", "avize"]);
-}
+    #[test]
+    fn test_matches_set_positive(s in "[a-z]{2}i[sz]e") {
+        let pattern = Pattern::new("..i[sz]e").unwrap();
+        assert_eq!(pattern.matches(s.as_str()), true);
+    }
 
-#[test]
-fn test_matches_negset() {
-    let wordlist = ["anise", "avize", "alice", "taire"];
-    let pattern = Pattern::new("..i[!sz]e").unwrap();
-    let result: Vec<&str> = wordlist
-        .into_iter()
-        .filter(|w| pattern.matches(w))
-        .collect();
-    assert_eq!(result, vec!["alice", "taire"]);
+    #[test]
+    fn test_not_matches_set_miss(s in "[a-z]{2}i[a-rt-y]e") {
+        let pattern = Pattern::new("..i[sz]e").unwrap();
+        assert_eq!(pattern.matches(s.as_str()), false);
+    }
+
+    #[test]
+    fn test_matches_negset_positive(s in "[a-z]{2}i[a-rt-y]e") {
+        let pattern = Pattern::new("..i[!sz]e").unwrap();
+        assert_eq!(pattern.matches(s.as_str()), true);
+    }
+
+    #[test]
+    fn test_not_matches_negset_miss(s in "[a-z]{2}i[sz]e") {
+        let pattern = Pattern::new("..i[!sz]e").unwrap();
+        assert_eq!(pattern.matches(s.as_str()), false);
+    }
+
+    #[test]
+    fn test_matches_set_range_positive(s in "[l-p][a-z][m-r][a-z][w-z]") {
+        let pattern = Pattern::new("[l-p].[m-r].[w-z]").unwrap();
+        assert_eq!(pattern.matches(s.as_str()), true);
+    }
+
+    #[test]
+    fn test_not_matches_set_range_miss(s in "([a-kq-z][a-z]{4}|[a-z]{2}[a-ls-z][a-z]{2}|[a-z]{4}[a-v])") {
+        let pattern = Pattern::new("[l-p].[m-r].[w-z]").unwrap();
+        assert_eq!(pattern.matches(s.as_str()), false);
+    }
 }
 
 #[test]

--- a/tests/matching-tests.rs
+++ b/tests/matching-tests.rs
@@ -27,7 +27,7 @@ proptest! {
     }
 
     #[test]
-    fn test_not_matches_crossword_wrong_length(s in "([a-z]{0,3}|[a-z]{4,})") {
+    fn test_not_matches_crossword_wrong_length(s in "([a-z]{0,3}|[a-z]{5,})") {
         let pattern = Pattern::new("l..e").unwrap();
         assert_eq!(pattern.matches(s.as_str()), false);
     }

--- a/tests/matching-tests.rs
+++ b/tests/matching-tests.rs
@@ -1,14 +1,36 @@
 use wordqat::pattern::Pattern;
+use proptest::prelude::*;
 
-#[test]
-fn test_matches_crossword() {
-    let wordlist = ["lone", "love", "word", "door", "dome", "lint", "leftie"];
-    let pattern = Pattern::new("l..e").unwrap();
-    let result: Vec<&str> = wordlist
-        .into_iter()
-        .filter(|w| pattern.matches(w))
-        .collect();
-    assert_eq!(result, vec!["lone", "love"]);
+proptest! {
+    #[test]
+    fn test_matches_fixed(s in "[a-z]+") {
+        let pattern = Pattern::new(s.as_str()).unwrap();
+        assert_eq!(pattern.matches(s.as_str()), true);
+    }
+
+    #[test]
+    fn test_matches_empty(s in "[a-z]*") {
+        let pattern = Pattern::new("").unwrap();
+        assert_eq!(pattern.matches(s.as_str()), s.as_str() == "");
+    }
+
+    #[test]
+    fn test_matches_crossword_positive(s in "l[a-z]{2}e") {
+        let pattern = Pattern::new("l..e").unwrap();
+        assert_eq!(pattern.matches(s.as_str()), true);
+    }
+
+    #[test]
+    fn test_not_matches_crossword_wrong_letters(s in "([^l][a-z]{3}|[a-z]{3}[^e])") {
+        let pattern = Pattern::new("l..e").unwrap();
+        assert_eq!(pattern.matches(s.as_str()), false);
+    }
+
+    #[test]
+    fn test_not_matches_crossword_wrong_length(s in "([a-z]{0,3}|[a-z]{4,})") {
+        let pattern = Pattern::new("l..e").unwrap();
+        assert_eq!(pattern.matches(s.as_str()), false);
+    }
 }
 
 #[test]

--- a/tests/matching-tests.rs
+++ b/tests/matching-tests.rs
@@ -1,5 +1,5 @@
-use wordqat::pattern::Pattern;
 use proptest::prelude::*;
+use wordqat::pattern::Pattern;
 
 proptest! {
     #[test]

--- a/tests/matching-tests.rs
+++ b/tests/matching-tests.rs
@@ -96,14 +96,3 @@ fn test_matches_consonants() {
         .collect();
     assert_eq!(result, vec!["wins", "worn"]);
 }
-
-#[test]
-fn test_set_range() {
-    let wordlist = ["lapaz", "parix", "other"];
-    let pattern = Pattern::new("[l-p].[m-r].[w-z]").unwrap();
-    let result: Vec<&str> = wordlist
-        .into_iter()
-        .filter(|w| pattern.matches(w))
-        .collect();
-    assert_eq!(result, vec!["lapaz", "parix"]);
-}


### PR DESCRIPTION
Refactors the pattern struct to use automata for matching instead of a vector of nodes. This will make the implementation considerably more scalable in the future, and allow things like adding wildcards. Still want to do a bit of refactoring and battle-testing before the final merge.

Resolves #2 